### PR TITLE
86a3a1kwz - Agregar Guards a los endpoints de creacion de topics, question, choice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
+        "@types/passport-jwt": "^4.0.1",
         "@types/passport-local": "^1.0.38",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -2310,6 +2311,16 @@
       "dev": true,
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
       }
     },
     "node_modules/@types/passport-local": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
+    "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/src/lib/common/types.ts
+++ b/src/lib/common/types.ts
@@ -1,3 +1,7 @@
 import { Types } from 'mongoose';
 
 export type MongoObjectId = Types.ObjectId;
+export enum ROLE {
+  'ADMIN' = 'ADMIN',
+  'USER' = 'USER',
+}

--- a/src/lib/security/roles.decorator.ts
+++ b/src/lib/security/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { Reflector } from '@nestjs/core';
+import { ROLE } from '../common/types';
+
+export const Roles = Reflector.createDecorator<ROLE[]>();

--- a/src/lib/security/roles.guard.ts
+++ b/src/lib/security/roles.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Roles } from './roles.decorator';
+import { User } from 'src/resources/user/entities/user.entity';
+import { ROLE } from '../common/types';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const roles = this.reflector.get(Roles, context.getHandler());
+    console.log({ roles });
+
+    if (!roles) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as User;
+    return roles.some((role) => user.roles.includes(role));
+  }
+}

--- a/src/lib/security/roles.guard.ts
+++ b/src/lib/security/roles.guard.ts
@@ -10,8 +10,6 @@ export class RolesGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const roles = this.reflector.get(Roles, context.getHandler());
-    console.log({ roles });
-
     if (!roles) {
       return true;
     }

--- a/src/resources/auth/auth.module.ts
+++ b/src/resources/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
@@ -10,6 +10,7 @@ import { jwtSecret } from './passport/constant';
 import { UserService } from '../user/user.service';
 import { UserModule } from '../user/user.module';
 import { MailerService } from '../mail/mailer.service';
+import { JwtStrategy } from './passport/jwt.strategy';
 
 @Module({
   imports: [
@@ -24,7 +25,13 @@ import { MailerService } from '../mail/mailer.service';
     UserModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthRepository, UserService, MailerService],
+  providers: [
+    AuthService,
+    AuthRepository,
+    UserService,
+    MailerService,
+    JwtStrategy,
+  ],
   exports: [AuthService, AuthRepository, MongooseModule],
 })
 export class AuthModule {}

--- a/src/resources/auth/auth.service.ts
+++ b/src/resources/auth/auth.service.ts
@@ -34,10 +34,14 @@ export class AuthService {
 
   async getToken(
     getTokenDto: GetTokenDto,
-  ): Promise<{ token: string; user: any }> {
+  ): Promise<{ token: string; user: Partial<User> }> {
     const auth = await this.authRepository.getToken(getTokenDto);
     const user = await this.userService.findAuth(auth._id);
-    const payload = { id: String(user._id), name: user.firstname };
+    const payload = {
+      id: String(user._id),
+      name: user.firstname,
+      roles: user.roles,
+    };
     return { token: this.jwtService.sign(payload), user: payload };
   }
 

--- a/src/resources/choice/choice.controller.ts
+++ b/src/resources/choice/choice.controller.ts
@@ -7,12 +7,14 @@ import {
   Param,
   Delete,
   Version,
+  UseGuards,
 } from '@nestjs/common';
 import { ChoiceService } from './choice.service';
 import { CreateChoiceDto } from './dto/create-choice.dto';
 import { UpdateChoiceDto } from './dto/update-choice.dto';
 import { ObjectId } from 'mongoose';
 import { DbRepository } from '../db/db.repository';
+import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
 
 @Controller('choice')
 export class ChoiceController {
@@ -22,6 +24,7 @@ export class ChoiceController {
   ) {}
 
   @Version('1')
+  @UseGuards(JwtAuthGuard)
   @Post('/:questionId')
   async create(
     @Param('questionId') questionId: ObjectId,

--- a/src/resources/choice/choice.controller.ts
+++ b/src/resources/choice/choice.controller.ts
@@ -15,6 +15,9 @@ import { UpdateChoiceDto } from './dto/update-choice.dto';
 import { ObjectId } from 'mongoose';
 import { DbRepository } from '../db/db.repository';
 import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
+import { ROLE } from 'src/lib/common/types';
+import { Roles } from 'src/lib/security/roles.decorator';
+import { RolesGuard } from 'src/lib/security/roles.guard';
 
 @Controller('choice')
 export class ChoiceController {
@@ -24,7 +27,8 @@ export class ChoiceController {
   ) {}
 
   @Version('1')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles([ROLE.ADMIN])
   @Post('/:questionId')
   async create(
     @Param('questionId') questionId: ObjectId,

--- a/src/resources/question/question.controller.ts
+++ b/src/resources/question/question.controller.ts
@@ -15,6 +15,9 @@ import { UpdateQuestionDto } from './dto/update-question.dto';
 import { ObjectId } from 'mongoose';
 import { DbRepository } from '../db/db.repository';
 import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
+import { RolesGuard } from 'src/lib/security/roles.guard';
+import { Roles } from 'src/lib/security/roles.decorator';
+import { ROLE } from 'src/lib/common/types';
 
 @Controller('question')
 export class QuestionController {
@@ -23,7 +26,8 @@ export class QuestionController {
     private readonly dbRepository: DbRepository,
   ) {}
   @Version('1')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles([ROLE.ADMIN])
   @Post('/:topicId')
   async create(
     @Param('topicId') topicId: ObjectId,

--- a/src/resources/question/question.controller.ts
+++ b/src/resources/question/question.controller.ts
@@ -7,12 +7,14 @@ import {
   Param,
   Delete,
   Version,
+  UseGuards,
 } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { UpdateQuestionDto } from './dto/update-question.dto';
 import { ObjectId } from 'mongoose';
 import { DbRepository } from '../db/db.repository';
+import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
 
 @Controller('question')
 export class QuestionController {
@@ -21,6 +23,7 @@ export class QuestionController {
     private readonly dbRepository: DbRepository,
   ) {}
   @Version('1')
+  @UseGuards(JwtAuthGuard)
   @Post('/:topicId')
   async create(
     @Param('topicId') topicId: ObjectId,

--- a/src/resources/topic/topic.controller.ts
+++ b/src/resources/topic/topic.controller.ts
@@ -14,19 +14,24 @@ import { CreateTopicDto } from './dto/create-topic.dto';
 import { UpdateTopicDto } from './dto/update-topic.dto';
 import { ObjectId } from 'mongoose';
 import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
+import { RolesGuard } from 'src/lib/security/roles.guard';
+import { Roles } from 'src/lib/security/roles.decorator';
+import { ROLE } from 'src/lib/common/types';
 
 @Controller('topic')
 export class TopicController {
   constructor(private readonly topicService: TopicService) {}
 
   @Version('1')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles([ROLE.ADMIN])
   @Post()
   create(@Body() createTopicDto: CreateTopicDto) {
     return this.topicService.create(createTopicDto);
   }
   @Version('1')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles([ROLE.ADMIN, ROLE.USER])
   @Get()
   findAll() {
     return this.topicService.findAll();

--- a/src/resources/topic/topic.controller.ts
+++ b/src/resources/topic/topic.controller.ts
@@ -13,18 +13,20 @@ import { TopicService } from './topic.service';
 import { CreateTopicDto } from './dto/create-topic.dto';
 import { UpdateTopicDto } from './dto/update-topic.dto';
 import { ObjectId } from 'mongoose';
+import { JwtAuthGuard } from '../auth/passport/jwt-auth.guard';
 
 @Controller('topic')
 export class TopicController {
   constructor(private readonly topicService: TopicService) {}
 
   @Version('1')
-  // @UseGuards() // esto para mas adelante, para que chequee que el que lo hace sea "ADMIN"
+  @UseGuards(JwtAuthGuard)
   @Post()
   create(@Body() createTopicDto: CreateTopicDto) {
     return this.topicService.create(createTopicDto);
   }
   @Version('1')
+  @UseGuards(JwtAuthGuard)
   @Get()
   findAll() {
     return this.topicService.findAll();

--- a/src/resources/user/entities/user.entity.ts
+++ b/src/resources/user/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsEnum, IsString } from 'class-validator';
 import { Document, HydratedDocument, Types } from 'mongoose';
+import { ROLE } from 'src/lib/common/types';
 import { Auth } from 'src/resources/auth/entities/auth.entity';
 
 export type UserDocument = HydratedDocument<User>;
@@ -18,6 +19,10 @@ export class User extends Document {
   @IsEmail()
   @Prop({ unique: true, required: true })
   email: string;
+
+  @IsEnum(ROLE)
+  @Prop({ required: true, default: ROLE.USER })
+  roles: ROLE[];
 
   @Prop({ uique: true, type: Types.ObjectId, ref: 'Auth' })
   auth: Auth;

--- a/src/resources/user/user.repository.ts
+++ b/src/resources/user/user.repository.ts
@@ -30,4 +30,12 @@ export class UserRepository {
       throw new HttpException('ERROR_FINDING_USER', HttpStatus.BAD_REQUEST);
     }
   }
+  async findById(userId: MongoObjectId): Promise<User> {
+    try {
+      return await this.userModel.findById(userId);
+    } catch (error) {
+      console.log('ERROR_FINDING_USER', error);
+      throw new HttpException('ERROR_FINDING_USER', HttpStatus.BAD_REQUEST);
+    }
+  }
 }

--- a/src/resources/user/user.service.ts
+++ b/src/resources/user/user.service.ts
@@ -16,6 +16,9 @@ export class UserService {
   async findAuth(auth: MongoObjectId) {
     return await this.userRepository.findAuth(auth);
   }
+  async findById(userId: MongoObjectId) {
+    return await this.userRepository.findById(userId);
+  }
 
   findAll() {
     return `This action returns all user`;


### PR DESCRIPTION
No aprobar hasta tener los dos anteriores!

Nuevo:
- infra de guards
- ADMIN guards role en los endpoints importantes. El GET /topic quedo con ADMIN y USER como muestra, mas tarde puede cambiar. 
- enum ROLE

Agregado: 
- findById method en user.service y user.repository. Esto lo use por una cuestion del jwt que despues resolvi de otra manera. De todas formas lo vamos a usar mas adelante asi que ya queda
- Roles en la entidad del usuario

Modificado:
- Se agrego role al payload en getToken para que tenga mas informacion del user al momento de usar el jwtGaurd
